### PR TITLE
timestamp field should be `time`

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ influent
 
         // super simple point
         client.write({ key: "myseries", value: 10 });
-            
+
         // more explicit point
         client
             .write({
@@ -60,7 +60,7 @@ influent
                 fields: {
                     some_field: 10
                 },
-                timestamp: Date.now()
+                time: Date.now()
             })
             .then(function() {
                 // ...
@@ -95,14 +95,14 @@ client
         fields: {
             // this will be written as 10i, and saved as int64 10 into InfluxDB
             some_field: new influent.Value(10, influent.type.INT64),
-            
+
             // another way to do the same thing, is to pass this value description
             another_field: {
                 data: 10,
                 type: influent.type.INT64
             }
         },
-        timestamp: Date.now()
+        time: Date.now()
     });
 ```
 
@@ -122,17 +122,17 @@ The `config` should have structure like:
         host:     string
         port:     number
     }
-    
+
     // or
-    
+
     server: [ serverA... serverN ]
-    
+
     username: string
     password: string
     database: string
-    
+
     // optional:
-    
+
     precision:  enum[n, u, ms, s, m, h]
     epoch:      enum[n, u, ms, s, m, h]
     max_batch:  number
@@ -157,13 +157,13 @@ The `config` should have structure like:
         host:     string
         port:     number
     }
-    
+
     // or
-    
+
     server: [ serverA... serverN ]
-    
+
     // optional:
-    
+
     max_batch:  number
     safe_limit: number
 }
@@ -214,7 +214,7 @@ Where options could be like:
     username:   string,
     password:   string,
     database:   string,
-    
+
     max_batch:  number,
     chunk_size: number,
     precision:  enum[n, u, ms, s, m, h]
@@ -306,7 +306,7 @@ When measurement is `Object`, it should have structure like:
     tags: {
         tagName: string
     },
-    timestamp: number | string | Date
+    time: number | string | Date
 }
 ```
 
@@ -406,9 +406,9 @@ ______________________
 ##### `new influent.Measurement(key: string)`
 ##### `measurement.addTag(key: string, value: string)`
 ##### `measurement.addField(key: string, value: influent.Value)`
-##### `measurement.setTimestamp(timestamp: string)`
+##### `measurement.setTimestamp(time: string)`
 
-Sets timestamp to the measurement. Using numeric `string`, [cause it make sense](https://github.com/gobwas/influent/pull/1#issuecomment-137720514) 
+Sets time stamp for the measurement. Using numeric `string`, [cause it make sense](https://github.com/gobwas/influent/pull/1#issuecomment-137720514)
 on a big numbers with precision in nanoseconds.
 
 ______________________

--- a/dist/influent.js
+++ b/dist/influent.js
@@ -116,7 +116,7 @@ function tryCastMeasurement(def) {
         });
     }
 
-    timestamp = def.timestamp;
+    timestamp = def.time;
     if (!_.isUndefined(timestamp)) {
         if (_.isString(timestamp)) {
             measurement.setTimestamp(timestamp);
@@ -730,7 +730,7 @@ function Measurement(key) {
 
     this.tags = {};
     this.fields = {};
-    this.timestamp = null;
+    this.time = null;
 }
 
 Measurement.prototype = {
@@ -756,9 +756,9 @@ Measurement.prototype = {
         return this;
     },
 
-    setTimestamp: function(timestamp) {
-        assert(_.isNumericString(timestamp), "Numeric string is expected :" + timestamp);
-        this.timestamp = timestamp;
+    setTimestamp: function(time) {
+        assert(_.isNumericString(time), "Numeric string is expected :" + time);
+        this.time = time;
     }
 };
 
@@ -956,7 +956,7 @@ LineSerializer = Serializer.extend(
                     };
                 })());
 
-                if (timestamp = measurement.timestamp) {
+                if (timestamp = measurement.time) {
                     line += " " + timestamp;
                 }
 
@@ -2310,7 +2310,7 @@ XhrHttp = Http.extend(
                 });
 
                 try {
-                    xhr.open(method, url, true);                    
+                    xhr.open(method, url, true);
                 } catch (err) {
                     reject(err);
                     return
@@ -3869,14 +3869,14 @@ exports.createHttpClient = function(config) {
     // use line serializer
     client.injectSerializer(new LineSerializer());
 
-    
 
-    
-    
+
+
+
     //use http lib
     client.injectHttp(new XhrHttp());
-    
-    
+
+
 
     // use base election strategy
     // with http ping option
@@ -3892,13 +3892,13 @@ exports.createHttpClient = function(config) {
 
     ping = new HttpPing(pingConfig);
 
-    
 
-    
-    
+
+
+
     ping.injectHttp(new XhrHttp());
-    
-    
+
+
 
     elector = new BaseElector(hosts, electorConfig);
     elector.injectPing(ping);

--- a/lib/client/decorator.js
+++ b/lib/client/decorator.js
@@ -60,7 +60,7 @@ function tryCastMeasurement(def) {
         });
     }
 
-    timestamp = def.timestamp;
+    timestamp = def.time;
     if (!_.isUndefined(timestamp)) {
         if (_.isString(timestamp)) {
             measurement.setTimestamp(timestamp);

--- a/lib/measurement.js
+++ b/lib/measurement.js
@@ -16,7 +16,7 @@ function Measurement(key) {
 
     this.tags = {};
     this.fields = {};
-    this.timestamp = null;
+    this.time = null;
 }
 
 Measurement.prototype = {
@@ -42,9 +42,9 @@ Measurement.prototype = {
         return this;
     },
 
-    setTimestamp: function(timestamp) {
-        assert(_.isNumericString(timestamp), "Numeric string is expected :" + timestamp);
-        this.timestamp = timestamp;
+    setTimestamp: function(time) {
+        assert(_.isNumericString(time), "Numeric string is expected :" + time);
+        this.time = time;
     }
 };
 

--- a/lib/serializer/line.js
+++ b/lib/serializer/line.js
@@ -147,7 +147,7 @@ LineSerializer = Serializer.extend(
                     };
                 })());
 
-                if (timestamp = measurement.timestamp) {
+                if (timestamp = measurement.time) {
                     line += " " + timestamp;
                 }
 

--- a/test/system/ex.js
+++ b/test/system/ex.js
@@ -48,7 +48,7 @@ describe("System tests", function() {
             })
             .then(function(client) {
                 return client
-                    .write({ key: "sut", fields: { value: "abcd" }, timestamp: 0 })
+                    .write({ key: "sut", fields: { value: "abcd" }, time: 0 })
                     .then(function() {
                         return client.query("select * from sut");
                     })
@@ -88,7 +88,7 @@ describe("System tests", function() {
                     .write({
                         key: "sutudp",
                         value: "hello_udp",
-                        timestamp: 0
+                        time: 0
                     })
                     .then(sleep(5))
                     .then(function() {
@@ -116,7 +116,7 @@ describe("System tests", function() {
             })
             .then(function(client) {
                 return client
-                    .write({ key: "sut", fields: { value: "abcd" }, timestamp: 0 })
+                    .write({ key: "sut", fields: { value: "abcd" }, time: 0 })
                     .catch(function(err) {
                         expect(err.message).equal("InfluxDB unauthorized user");
                     });

--- a/test/unit/client/decorator.js
+++ b/test/unit/client/decorator.js
@@ -171,7 +171,7 @@ describe("DecoratorClient", function() {
             // when
             result = instance.write([{
                 key: "key",
-                timestamp: stamp
+                time: stamp
             }]);
 
             // then
@@ -182,7 +182,7 @@ describe("DecoratorClient", function() {
 
                 measurement = writeStub.firstCall.args[0][0];
 
-                expect(measurement.timestamp).equal(stamp.toString());
+                expect(measurement.time).equal(stamp.toString());
             });
         });
 


### PR DESCRIPTION
Using influxDb `timestamp` in measurements sent to Influx simply resulted in 1970 dates.  This fixes that.

Note: This is not tested unfortunately, but I did attempt to roll the changes out to the test suite.
